### PR TITLE
Upgrade from lts-3.13 to lts-14.7

### DIFF
--- a/hdr-histogram.cabal
+++ b/hdr-histogram.cabal
@@ -22,7 +22,7 @@ library
                        Data.HdrHistogram.Mutable
                        Data.HdrHistogram.Tutorial
   build-depends:       base >= 4.7 && < 5
-                     , vector >= 0.10 && < 0.12
+                     , vector >= 0.12 && < 0.13
                      , primitive >= 0.6 && < 0.7
                      , deepseq >= 1.4 && < 1.5
                      , tagged >= 0.8 && < 0.9

--- a/src/Data/HdrHistogram.hs
+++ b/src/Data/HdrHistogram.hs
@@ -58,9 +58,13 @@ fromConfig (Tagged c) = Histogram {
   }
 
 instance (HasConfig config, Integral value, FiniteBits value, U.Unbox count, Integral count) =>
+         Semigroup (Histogram config value count) where
+  Histogram config' t c <> Histogram _ t' c' = Histogram config' (t + t') (U.zipWith (+) c c')
+
+instance (HasConfig config, Integral value, FiniteBits value, U.Unbox count, Integral count) =>
          Monoid (Histogram config value count) where
   mempty = empty
-  Histogram config' t c `mappend` Histogram _ t' c' = Histogram config' (t + t') (U.zipWith (+) c c')
+  mappend = (<>)
 
 -- | Record a single value to the 'Histogram'
 record :: (U.Unbox count,

--- a/src/Data/HdrHistogram/Config.hs
+++ b/src/Data/HdrHistogram/Config.hs
@@ -15,7 +15,6 @@ and from 'Int' indices, regardless of mutability or memory layout.
 -}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE TypeFamilies        #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.13
+resolver: lts-14.7
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This requires a new `Semigroup` instance. I just moved the `Monoid.mappend` implementation into `Semigroup.(+)`.